### PR TITLE
Fix singletons to use proper volatile double-checked locking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ spotbugs {
     toolVersion = '3.1.11'
     effort = 'max'
     reportLevel = 'low'
+    sourceSets = []
 }
 
 tasks.withType(com.github.spotbugs.SpotBugsTask) {

--- a/src/main/java/frc/team4373/robot/input/OI.java
+++ b/src/main/java/frc/team4373/robot/input/OI.java
@@ -13,7 +13,7 @@ import frc.team4373.robot.input.filters.XboxAxisFilter;
  * OI provides access to operator interface devices.
  */
 public class OI {
-    private static OI oi = null;
+    private static volatile OI oi = null;
     private RooJoystick<FineGrainedPiecewiseFilter> driveJoystick;
     private RooJoystick operatorJoystick;
 

--- a/src/main/java/frc/team4373/robot/subsystems/Climber.java
+++ b/src/main/java/frc/team4373/robot/subsystems/Climber.java
@@ -10,10 +10,21 @@ import frc.team4373.robot.commands.DummyCommand;
  * A programmatic representation of the robot's climbing components.
  */
 public class Climber extends Subsystem {
-    private static Climber instance;
+    private static volatile Climber instance;
 
+    /**
+     * The getter for the Climber class.
+     * @return the singleton Climber object.
+     */
     public static Climber getInstance() {
-        return instance == null ? instance = new Climber() : instance;
+        if (instance == null) {
+            synchronized (Climber.class) {
+                if (instance == null) {
+                    instance = new Climber();
+                }
+            }
+        }
+        return instance;
     }
 
     private DoubleSolenoid frontPiston;

--- a/src/main/java/frc/team4373/robot/subsystems/ClimberDrive.java
+++ b/src/main/java/frc/team4373/robot/subsystems/ClimberDrive.java
@@ -12,10 +12,21 @@ import frc.team4373.robot.commands.teleop.ClimberDriveCommand;
  * A programmatic representation of the drivetrain of the climbing system.
  */
 public class ClimberDrive extends Subsystem {
-    private static ClimberDrive instance;
+    private static volatile ClimberDrive instance;
 
+    /**
+     * The getter for the ClimberDrive class.
+     * @return the singleton ClimberDrive object.
+     */
     public static ClimberDrive getInstance() {
-        return instance == null ? instance = new ClimberDrive() : instance;
+        if (instance == null) {
+            synchronized (ClimberDrive.class) {
+                if (instance == null) {
+                    instance = new ClimberDrive();
+                }
+            }
+        }
+        return instance;
     }
 
     private WPI_TalonSRX talon;

--- a/src/main/java/frc/team4373/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/team4373/robot/subsystems/Drivetrain.java
@@ -15,10 +15,21 @@ import frc.team4373.robot.commands.teleop.DrivetrainCommand;
  * A programmatic representation of the robot's drivetrain.
  */
 public class Drivetrain extends Subsystem {
-    private static Drivetrain instance;
+    private static volatile Drivetrain instance;
 
+    /**
+     * The getter for the Drivetrain class.
+     * @return the singleton Drivetrain object.
+     */
     public static Drivetrain getInstance() {
-        return instance == null ? instance = new Drivetrain() : instance;
+        if (instance == null) {
+            synchronized (Drivetrain.class) {
+                if (instance == null) {
+                    instance = new Drivetrain();
+                }
+            }
+        }
+        return instance;
     }
 
     public enum TalonID {

--- a/src/main/java/frc/team4373/robot/subsystems/Intake.java
+++ b/src/main/java/frc/team4373/robot/subsystems/Intake.java
@@ -21,10 +21,21 @@ public class Intake extends Subsystem {
     private DoubleSolenoid deployPiston1;
     private DigitalInput limitSwitch;
 
-    private static Intake instance;
+    private static volatile Intake instance;
 
+    /**
+     * The getter for the Intake class.
+     * @return the singleton Intake object.
+     */
     public static Intake getInstance() {
-        return instance == null ? instance = new Intake() : instance;
+        if (instance == null) {
+            synchronized (Intake.class) {
+                if (instance == null) {
+                    instance = new Intake();
+                }
+            }
+        }
+        return instance;
     }
 
     private Intake() {

--- a/src/main/java/frc/team4373/robot/subsystems/Lift.java
+++ b/src/main/java/frc/team4373/robot/subsystems/Lift.java
@@ -15,10 +15,21 @@ import frc.team4373.robot.commands.teleop.LiftCommand;
  * A programmatic representation of the robot's lift mechanism that supports the intake.
  */
 public class Lift extends Subsystem {
-    private static Lift instance;
+    private static volatile Lift instance;
 
+    /**
+     * The getter for the Lift class.
+     * @return the singleton Lift object.
+     */
     public static Lift getInstance() {
-        return instance == null ? instance = new Lift() : instance;
+        if (instance == null) {
+            synchronized (Lift.class) {
+                if (instance == null) {
+                    instance = new Lift();
+                }
+            }
+        }
+        return instance;
     }
 
     private WPI_TalonSRX talon1;


### PR DESCRIPTION
Our subsystem singletons are really not thread-safe. Our OI singleton is sort of thread-safe. This makes all of our singletons thread-safe.